### PR TITLE
fix: cursor pos is not at the end of line

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+charset = utf-8

--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ https://github.com/user-attachments/assets/d9bd8a00-54cd-4264-83a8-2ad4d82d64dc
 ### Configuration
 
 ```lua
-  {
-    enabled = false, -- Turned off by default
-    keymap = "<leader>R" -- Keymap used to toggle ReaderMode on/off
-  }
+{
+  enabled = false, -- Turned off by default
+  keymap = "<leader>R" -- Keymap used to toggle ReaderMode on/off
+  desc = "Toggle Reader Mode", -- Description keymap
+  allow_filetypes = {}, -- Allow to take effect in these file types
+  denied_filetypes = {}, -- Denied to take effect in these file types
+}
 ```
 
 ## Usage

--- a/doc/readermode.nvim.txt
+++ b/doc/readermode.nvim.txt
@@ -40,10 +40,13 @@ LAZY.NVIM ~
 CONFIGURATION ~
 
 >lua
-      {
-        enabled = false, -- Turned off by default
-        keymap = "<leader>R" -- Keymap used to toggle ReaderMode on/off
-      }
+   {
+      enabled = false, -- Turned off by default
+      keymap = "<leader>R" -- Keymap used to toggle ReaderMode on/off
+      desc = "Toggle Reader Mode", -- Description keymap
+      allow_filetypes = {}, -- Allow to take effect in these file types
+      denied_filetypes = {}, -- Denied to take effect in these file types
+   }
 <
 
 

--- a/lua/readermode/init.lua
+++ b/lua/readermode/init.lua
@@ -7,11 +7,11 @@ local M = {}
 ---@field allow_filetypes? string[]
 ---@field denied_filetypes? string[]
 local defaults = {
-	enabled = false,
-	keymap = "<leader>R",
-	desc = "Toggle Reader Mode",
-	allow_filetypes = {},
-	denied_filetypes = {},
+  enabled = false,
+  keymap = "<leader>R",
+  desc = "Toggle Reader Mode",
+  allow_filetypes = {},
+  denied_filetypes = {},
 }
 
 ---@type ReaderModeOptions
@@ -19,74 +19,74 @@ M.opts = {}
 
 ---@param opts? ReaderModeOptions
 function M.setup(opts)
-	M.opts = vim.tbl_deep_extend("force", defaults, opts or {}) or {}
+  M.opts = vim.tbl_deep_extend("force", defaults, opts or {}) or {}
 
-	-- Define ways to toggle readermode
-	vim.api.nvim_create_user_command("ReaderMode", require("readermode").toggle, {})
-	vim.keymap.set({ "n" }, M.opts.keymap, M.toggle, { desc = M.opts.desc })
+  -- Define ways to toggle readermode
+  vim.api.nvim_create_user_command("ReaderMode", require("readermode").toggle, {})
+  vim.keymap.set({ "n" }, M.opts.keymap, M.toggle, { desc = M.opts.desc })
 
-	local last_line = M.getCurrentLineNumber()
+  local last_line = M.getCurrentLineNumber()
 
-	-- Define Autocommand w/ new Autogroup
-	vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
-		group = vim.api.nvim_create_augroup("ReaderMode", { clear = true }),
-		callback = function()
-			local enabled = M.opts.enabled
-			local allow_filetypes = M.opts.allow_filetypes
-			---@cast allow_filetypes table
-			local denied_filetypes = M.opts.denied_filetypes
-			---@cast denied_filetypes table
+  -- Define Autocommand w/ new Autogroup
+  vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
+    group = vim.api.nvim_create_augroup("ReaderMode", { clear = true }),
+    callback = function()
+      local enabled = M.opts.enabled
+      local allow_filetypes = M.opts.allow_filetypes
+      ---@cast allow_filetypes table
+      local denied_filetypes = M.opts.denied_filetypes
+      ---@cast denied_filetypes table
 
-			if enabled then
-				local filetype = vim.bo.filetype
+      if enabled then
+        local filetype = vim.bo.filetype
 
-				-- denied filetypes contains filetype
-				if vim.tbl_contains(denied_filetypes, filetype) then
-					return
-				end
+        -- denied filetypes contains filetype
+        if vim.tbl_contains(denied_filetypes, filetype) then
+          return
+        end
 
-				-- allow_filetypes is not empty and not contains filetype
-				if vim.tbl_isempty(allow_filetypes) ~= true and vim.tbl_contains(allow_filetypes, filetype) then
-					return
-				end
+        -- allow_filetypes is not empty and not contains filetype
+        if vim.tbl_isempty(allow_filetypes) ~= true and vim.tbl_contains(allow_filetypes, filetype) then
+          return
+        end
 
-				local current_line = M.getCurrentLineNumber()
-				local has_line_move = current_line ~= last_line
-				if has_line_move then
-					M.center()
+        local current_line = M.getCurrentLineNumber()
+        local has_line_move = current_line ~= last_line
+        if has_line_move then
+          M.center()
 
-					local mode = vim.api.nvim_get_mode().mode
-					if mode == "i" then
-						-- move cursor to the end of line on insert mode
-						local current_pos = vim.api.nvim_win_get_cursor(0)
-						local line = vim.api.nvim_get_current_line()
-						local end_pos = #line
-						vim.api.nvim_win_set_cursor(0, { current_pos[1], end_pos })
-					end
-				end
+          local mode = vim.api.nvim_get_mode().mode
+          if mode == "i" then
+            -- move cursor to the end of line on insert mode
+            local current_pos = vim.api.nvim_win_get_cursor(0)
+            local line = vim.api.nvim_get_current_line()
+            local end_pos = #line
+            vim.api.nvim_win_set_cursor(0, { current_pos[1], end_pos })
+          end
+        end
 
-				last_line = current_line
-			end
-		end,
-	})
+        last_line = current_line
+      end
+    end,
+  })
 end
 
 ---@return number
 function M.getCurrentLineNumber()
-	return vim.api.nvim_win_get_cursor(0)[1]
+  return vim.api.nvim_win_get_cursor(0)[1]
 end
 
 ---@return nil
 function M.toggle()
-	M.opts.enabled = not M.opts.enabled
-	if M.opts.enabled == true then
-		M.center()
-	end
+  M.opts.enabled = not M.opts.enabled
+  if M.opts.enabled == true then
+    M.center()
+  end
 end
 
 ---@return nil
 function M.center()
-	vim.cmd("normal! zz")
+  vim.cmd("normal! zz")
 end
 
 return M

--- a/lua/readermode/init.lua
+++ b/lua/readermode/init.lua
@@ -51,10 +51,20 @@ function M.setup(opts)
 				end
 
 				local current_line = M.getCurrentLineNumber()
-				if current_line ~= last_line then
+				local has_line_move = current_line ~= last_line
+				if has_line_move then
 					M.center()
-				else
+
+					local mode = vim.api.nvim_get_mode().mode
+					if mode == "i" then
+						-- move cursor to the end of line on insert mode
+						local current_pos = vim.api.nvim_win_get_cursor(0)
+						local line = vim.api.nvim_get_current_line()
+						local end_pos = #line
+						vim.api.nvim_win_set_cursor(0, { current_pos[1], end_pos })
+					end
 				end
+
 				last_line = current_line
 			end
 		end,

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,5 @@
+indent_type = "Spaces"
+indent_width = 2
+column_width = 120
+[sort_requires]
+enabled = true


### PR DESCRIPTION
1. When switch from n to i mode by default, the cursor is always not at the end of the line.
2. Standardize the code format